### PR TITLE
Prevent XSS via innerHTML

### DIFF
--- a/static/01-chat.html
+++ b/static/01-chat.html
@@ -45,7 +45,7 @@
         // listen to patches coming from the server
         room.onMessage(function(message) {
             var p = document.createElement("p");
-            p.innerHTML = message;
+            p.innerText = message;
             document.querySelector("#messages").appendChild(p);
         });
 

--- a/static/02-state-handler.html
+++ b/static/02-state-handler.html
@@ -56,7 +56,7 @@
                 dom.style.left = player.x + "px";
                 dom.style.top = player.y + "px";
                 dom.style.background = colors[Math.floor(Math.random() * colors.length)];
-                dom.innerHTML = "Player " + sessionId;
+                dom.innerText = "Player " + sessionId;
 
                 players[sessionId] = dom;
                 document.body.appendChild(dom);


### PR DESCRIPTION
Using `innerHTML` makes the examples vulnerable to cross-site scripting. To demonstrate, in the current version of the chat room example, one can enter `<img src='x' onerror='alert("xss!")'>` as a message, and the (arbitrary) javascript will run for all users in the room.

This can be prevented by changing `innerHTML` to `innerText` in all instances, which this pull req does.