### PR TITLE
Listening to `client.send("hello", "world");` msg.

### DIFF
--- a/static/02-state-handler.html
+++ b/static/02-state-handler.html
@@ -72,6 +72,10 @@
                 delete players[sessionId];
             }
 
+            
+            room.onMessage("hello", (message) => {
+                console.log(message);
+            });
 
             window.addEventListener("keydown", function (e) {
                 if (e.which === 38) {


### PR DESCRIPTION
**Before**: `client.send("hello", "world");` was sent from `onJoin` (in `02-state-handler.ts`) but that resulted in the following warning on the console: `onMessage not registered for type 'hello'`. 

**Now**: We listen to the 'hello' type and print the message onto the console. No warning, and we see a message when someone joins.