### PR TITLE
Set minimum instead of required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "heroku-postbuild": "npm run build"
   },
   "engines": {
-    "node": "8.9.1"
+    "node": ">=8.9.1"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Any Node version above 8.9.1 should work fine, tested with 12.18.3.

![image](https://user-images.githubusercontent.com/4076953/99782783-e28cff00-2b19-11eb-9bbd-54f328b3f02c.png)
